### PR TITLE
Update notify_teams.py

### DIFF
--- a/functions/notify_teams.py
+++ b/functions/notify_teams.py
@@ -92,5 +92,5 @@ def is_cloudwatch_alarm(message):
             return True
         else:
             return False
-    except ValueError as e:
+    except KeyError as e:
         return False


### PR DESCRIPTION
For non cloudwatch messages Im assuming we want to change this to a key error rather than value error since the current method is not working. 
```
[ERROR] KeyError: 'AlarmName'
Traceback (most recent call last):
  File "/var/task/notify_teams.py", line 18, in lambda_handler
    if is_cloudwatch_alarm(message):
  File "/var/task/notify_teams.py", line 91, in is_cloudwatch_alarm
    if message_json['AlarmName']:
```